### PR TITLE
add option to use non-default api password for basic auth

### DIFF
--- a/clage_homeserver/clage_homeserver.py
+++ b/clage_homeserver/clage_homeserver.py
@@ -9,6 +9,8 @@ from datetime import datetime
 import urllib3
 
 NUMBER_OF_CONNECTED_HEATERS = 1       # I have only one heater, so i start with this scenario
+DEFAULTUSER = 'appuser'
+DEFAULTPASSWORD = 'smart'
 
 class ClageHomeServerMapper:
 
@@ -166,10 +168,11 @@ class ClageHomeServer:
     ipAddress = ""
     homeserverId = ""
     heaterId = ""
-    username = "appuser"
-    password = "smart"
+    username = ""
+    password = ""
 
-    def __init__(self, ipAddress, homeserverId, heaterId):
+    def __init__(self, ipAddress, homeserverId, heaterId, password):
+        self.username = DEFAULTUSER
         if (ipAddress is None or ipAddress == ''):
             raise ValueError("ipAddress must be specified")
         self.ipAddress = ipAddress
@@ -179,7 +182,10 @@ class ClageHomeServer:
         if (heaterId is None or heaterId == ''):
             raise ValueError("heaterId must be specified")
         self.heaterId = heaterId
-
+        if (password is None or password == ''):                                                                                                                                                    
+            password = DEFAULTPASSWORD                                                                                                                                                              
+        self.password = password 
+    
     VERSION = {
         '1.4': '1.4'
     }


### PR DESCRIPTION
Hey!

Thanks for the great work beforehand.

I had trouble initializing your corresponding clage_homeserver integration for home assistant (https://github.com/klacol/homeassistant-clage_homeserver), so I did some digging and found out that the python lib always uses the default credentials for the API.

Being a security nerd, I never use default passwords - so I added the possibility to add the app password together with the other configuration options.

Tested locally - it fixed the issue for me. This is a breaking change, but this project doesn't seem to be used much "out in the wild" apart from home assistant. I'm happy to discuss approaches other than breaking the existing init signature.

Best,
Jan